### PR TITLE
Fix: Reserve Tarballs

### DIFF
--- a/Scripts/Installer/Arch/amd64/arch.sh
+++ b/Scripts/Installer/Arch/amd64/arch.sh
@@ -69,8 +69,6 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch Arch Linux with the ./${bin} script"
 echo "Preparing additional component for the first time, please wait..."
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/amd64/resolv.conf" -P arch-fs/root

--- a/Scripts/Installer/Arch/armhf/arch.sh
+++ b/Scripts/Installer/Arch/armhf/arch.sh
@@ -68,8 +68,6 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch Arch Linux with the ./${bin} script"
 echo "Preparing additional component for the first time, please wait..."
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/amd64/resolv.conf" -P arch-fs/root

--- a/Scripts/Installer/Debian/debian.sh
+++ b/Scripts/Installer/Debian/debian.sh
@@ -76,6 +76,4 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch Debian with the ./${bin} script"

--- a/Scripts/Installer/Fedora/fedora.sh
+++ b/Scripts/Installer/Fedora/fedora.sh
@@ -77,6 +77,4 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch Fedora with the ./${bin} script"

--- a/Scripts/Installer/Ubuntu/ubuntu.sh
+++ b/Scripts/Installer/Ubuntu/ubuntu.sh
@@ -76,6 +76,4 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch Ubuntu with the ./${bin} script"

--- a/Scripts/Installer/openSUSE/armhf/opensuse.sh
+++ b/Scripts/Installer/openSUSE/armhf/opensuse.sh
@@ -71,6 +71,4 @@ echo "fixing shebang of $bin"
 termux-fix-shebang $bin
 echo "making $bin executable"
 chmod +x $bin
-echo "removing image for some space"
-rm $tarball
 echo "You can now launch openSUSE with the ./${bin} script"


### PR DESCRIPTION
I have several modified scripts to use tarball in local backup directories. 

Only not removing tarball in those scripts makes it possible to use local backups.