### PR TITLE
Fixed partial upgrade on de-pac.sh

### DIFF
--- a/Scripts/DesktopEnvironment/Pacman/de-pac.sh
+++ b/Scripts/DesktopEnvironment/Pacman/de-pac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Get the necessary components
-pacman -Sy --noconfirm lxde tigervnc
+pacman -Syu --noconfirm lxde tigervnc
 
 #Setup the necessary files
 wget https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/DesktopEnvironment/Pacman/xstartup -P ~/.vnc/


### PR DESCRIPTION
Replaced `pac -Sy` to `pac -Syu`, partial upgrades are not good for Arch ecosystem.
Never do `pac -Sy`.