### PR TITLE
Fix sshd_config overwrite

### DIFF
--- a/Scripts/SSH/Apt/ssh-apt.sh
+++ b/Scripts/SSH/Apt/ssh-apt.sh
@@ -5,7 +5,7 @@ apt-get update
 apt-get install openssh-server -y
 
 #Setup the necessary files
-wget https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/SSH/Apt/sshd_config -P /etc/ssh
+wget https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/SSH/Apt/sshd_config -O /etc/ssh/sshd_config
 
 echo "You can now start OpenSSH Server by running /etc/init.d/ssh start"
 echo " "


### PR DESCRIPTION
Upon installing sshd, the sshd_config file is already present. So, using wget with the option -P, the file isn't overwrited but instead the file sshd_config.1 is created, and thus isn't active. With the -O option, the file will be overwritten.