### PR TITLE
Anlinux-Resources: use simple command for launch the rootfs.

### DIFF
--- a/Scripts/Installer/Alpine/alpine.sh
+++ b/Scripts/Installer/Alpine/alpine.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p alpine-binds
-bin=start-alpine.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A alpine-binds)" ]; then
-    for f in alpine-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/alpine-binds)" ]; then
+    for f in /data/data/com.termux/files/home/alpine-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b alpine-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/alpine-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,13 +72,13 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
 echo "Preparing additional component for the first time, please wait..."
 rm alpine-fs/etc/resolv.conf
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Alpine/resolv.conf" -P alpine-fs/etc
-echo "You can now launch Alpine with the ./${bin} script"
+echo 'You can now launch Alpine with the "start" command'

--- a/Scripts/Installer/Arch/amd64/arch.sh
+++ b/Scripts/Installer/Arch/amd64/arch.sh
@@ -27,7 +27,7 @@ if [ "$first" != 1 ];then
 fi
 mkdir -p arch-binds
 mkdir -p arch-fs/tmp
-bin=start-arch.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -37,15 +37,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A arch-binds)" ]; then
-    for f in arch-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/arch-binds)" ]; then
+    for f in /data/data/com.termux/files/home/arch-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b arch-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/arch-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -65,13 +65,13 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Arch Linux with the ./${bin} script"
+echo 'You can now launch Arch Linux with the "start" command'
 echo "Preparing additional component for the first time, please wait..."
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/amd64/resolv.conf" -P arch-fs/root
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/amd64/additional.sh" -P arch-fs/root

--- a/Scripts/Installer/Arch/armhf/arch.sh
+++ b/Scripts/Installer/Arch/armhf/arch.sh
@@ -26,7 +26,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p arch-binds
-bin=start-arch.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -43,15 +43,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A arch-binds)" ]; then
-    for f in arch-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/arch-binds)" ]; then
+    for f in /data/data/com.termux/files/home/arch-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b arch-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/arch-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -71,13 +71,13 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Arch Linux with the ./${bin} script"
+echo 'You can now launch Arch Linux with the "start" command'
 echo "Preparing additional component for the first time, please wait..."
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/armhf/resolv.conf" -P arch-fs/root
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Arch/armhf/additional.sh" -P arch-fs/root

--- a/Scripts/Installer/BackBox/backbox.sh
+++ b/Scripts/Installer/BackBox/backbox.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p backbox-binds
-bin=start-backbox.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A backbox-binds)" ]; then
-    for f in backbox-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/backbox-binds)" ]; then
+    for f in /data/data/com.termux/files/home/backbox-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b backbox-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/backbox-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,10 +72,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Backbox with the ./${bin} script"
+echo 'You can now launch Backbox with the "start" command'

--- a/Scripts/Installer/CentOS/centos.sh
+++ b/Scripts/Installer/CentOS/centos.sh
@@ -40,7 +40,7 @@ if [ "$first" != 1 ];then
 fi
 mkdir -p centos-binds
 mkdir -p centos-fs/tmp
-bin=start-centos.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -50,15 +50,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A centos-binds)" ]; then
-    for f in centos-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/centos-binds)" ]; then
+    for f in /data/data/com.termux/files/home/centos-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b centos-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/centos-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -78,10 +78,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch CentOS with the ./${bin} script"
+echo 'You can now launch CentOS with the "start" command'

--- a/Scripts/Installer/Debian/debian.sh
+++ b/Scripts/Installer/Debian/debian.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p debian-binds
-bin=start-debian.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A debian-binds)" ]; then
-    for f in debian-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/debian-binds)" ]; then
+    for f in /data/data/com.termux/files/home/debian-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b debian-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/debian-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,10 +72,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Debian with the ./${bin} script"
+echo 'You can now launch Debian with the "start" command'

--- a/Scripts/Installer/Fedora/fedora.sh
+++ b/Scripts/Installer/Fedora/fedora.sh
@@ -35,7 +35,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p fedora-binds
-bin=start-fedora.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -45,15 +45,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A fedora-binds)" ]; then
-    for f in fedora-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/fedora-binds)" ]; then
+    for f in /data/data/com.termux/files/home/fedora-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b fedora-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/fedora-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -73,10 +73,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Fedora with the ./${bin} script"
+echo 'You can now launch Fedora with the "start" command'

--- a/Scripts/Installer/Kali/kali.sh
+++ b/Scripts/Installer/Kali/kali.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p kali-binds
-bin=start-kali.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A kali-binds)" ]; then
-    for f in kali-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/kali-binds)" ]; then
+    for f in /data/data/com.termux/files/home/kali-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b kali-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/kali-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,10 +72,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Kali with the ./${bin} script"
+echo 'You can now launch Kali with the "start" command'

--- a/Scripts/Installer/Nethunter/nethunter.sh
+++ b/Scripts/Installer/Nethunter/nethunter.sh
@@ -37,7 +37,7 @@ echo "deb http://mirror.fsmg.org.nz/kali kali-rolling main contrib non-free" >> 
 echo "deb-src http://mirror.fsmg.org.nz/kali kali-rolling main contrib non-free" >> nethunter-fs/etc/apt/sources.list
 wget https://archive.kali.org/archive-key.asc -O nethunter-fs/etc/apt/trusted.gpg.d/kali-archive-key.asc
 mkdir -p nethunter-binds
-bin=start-nethunter.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -47,15 +47,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r nethunter-fs"
-if [ -n "\$(ls -A nethunter-binds)" ]; then
-    for f in nethunter-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/nethunter-fs"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/nethunter-binds)" ]; then
+    for f in /data/data/com.termux/files/home/nethunter-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b nethunter-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/nethunter-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -75,10 +75,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Kali Nethunter with the ./${bin} script"
+echo 'You can now launch Kali Nethunter with the "start" command'

--- a/Scripts/Installer/Parrot/parrot.sh
+++ b/Scripts/Installer/Parrot/parrot.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p parrot-binds
-bin=start-parrot.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A parrot-binds)" ]; then
-    for f in parrot-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/parrot-binds)" ]; then
+    for f in /data/data/com.termux/files/home/parrot-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b parrot-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/parrot-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,10 +72,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Parrot Security OS with the ./${bin} script"
+echo 'You can now launch Parrot Security OS with the "start" command'

--- a/Scripts/Installer/Ubuntu/ubuntu.sh
+++ b/Scripts/Installer/Ubuntu/ubuntu.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p ubuntu-binds
-bin=start-ubuntu.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A ubuntu-binds)" ]; then
-    for f in ubuntu-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/ubuntu-binds)" ]; then
+    for f in /data/data/com.termux/files/home/ubuntu-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b ubuntu-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/ubuntu-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,10 +72,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch Ubuntu with the ./${bin} script"
+echo 'You can now launch Ubuntu with the "start" command'

--- a/Scripts/Installer/Void/void.sh
+++ b/Scripts/Installer/Void/void.sh
@@ -34,7 +34,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p void-binds
-bin=start-void.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -44,15 +44,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A void-binds)" ]; then
-    for f in void-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/void-binds)" ]; then
+    for f in /data/data/com.termux/files/home/void-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b void-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/void-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -72,12 +72,12 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
 echo "Preparing additional component for the first time, please wait..."
 wget "https://raw.githubusercontent.com/EXALAB/AnLinux-Resources/master/Scripts/Installer/Void/resolv.conf" -P void-fs/etc
-echo "You can now launch Void Linux with the ./${bin} script"
+echo 'You can now launch Void Linux with the "start" command'

--- a/Scripts/Installer/openSUSE/Leap/opensuse-leap.sh
+++ b/Scripts/Installer/openSUSE/Leap/opensuse-leap.sh
@@ -35,7 +35,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p opensuse-leap-binds
-bin=start-leap.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -45,15 +45,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A opensuse-leap-binds)" ]; then
-    for f in opensuse-leap-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/opensuse-leap-binds)" ]; then
+    for f in /data/data/com.termux/files/home/opensuse-leap-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b opensuse-leap-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/opensuse-leap-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -73,10 +73,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch openSUSE Leap with the ./${bin} script"
+echo 'You can now launch openSUSE Leap with the "start" command'

--- a/Scripts/Installer/openSUSE/Tumbleweed/opensuse-tumbleweed.sh
+++ b/Scripts/Installer/openSUSE/Tumbleweed/opensuse-tumbleweed.sh
@@ -39,7 +39,7 @@ if [ "$first" != 1 ];then
 	cd "$cur"
 fi
 mkdir -p opensuse-tumbleweed-binds
-bin=start-tumbleweed.sh
+bin=/data/data/com.termux/files/usr/bin/start
 echo "writing launch script"
 cat > $bin <<- EOM
 #!/bin/bash
@@ -49,15 +49,15 @@ unset LD_PRELOAD
 command="proot"
 command+=" --link2symlink"
 command+=" -0"
-command+=" -r $folder"
-if [ -n "\$(ls -A opensuse-tumbleweed-binds)" ]; then
-    for f in opensuse-tumbleweed-binds/* ;do
+command+=" -r /data/data/com.termux/files/home/$folder"
+if [ -n "\$(ls -A /data/data/com.termux/files/home/opensuse-tumbleweed-binds)" ]; then
+    for f in /data/data/com.termux/files/home/opensuse-tumbleweed-binds/* ;do
       . \$f
     done
 fi
 command+=" -b /dev"
 command+=" -b /proc"
-command+=" -b opensuse-tumbleweed-fs/root:/dev/shm"
+command+=" -b /data/data/com.termux/files/home/opensuse-tumbleweed-fs/root:/dev/shm"
 ## uncomment the following line to have access to the home directory of termux
 #command+=" -b /data/data/com.termux/files/home:/root"
 ## uncomment the following line to mount /sdcard directly to / 
@@ -77,10 +77,10 @@ else
 fi
 EOM
 
-echo "fixing shebang of $bin"
+echo "fixing shebang of launch script"
 termux-fix-shebang $bin
-echo "making $bin executable"
+echo "making binary executable"
 chmod +x $bin
 echo "removing image for some space"
 rm $tarball
-echo "You can now launch openSUSE Tumbleweed with the ./${bin} script"
+echo 'You can now launch openSUSE Tumbleweed with the "start" command'


### PR DESCRIPTION
this allow users to simply type the "start" command instead of "./start-" scripts.