### PR TITLE
bug fix

### DIFF
--- a/Scripts/DesktopEnvironment/Apt/Xfce4/de-apt-xfce4.sh
+++ b/Scripts/DesktopEnvironment/Apt/Xfce4/de-apt-xfce4.sh
@@ -41,4 +41,4 @@ echo " "
 echo "export DISPLAY=":1"" >> /etc/profile
 source /etc/profile
 
-vncserver-start
+vncserver :1


### PR DESCRIPTION
"vncserver-start command not found"
for tightvncserver package provided by de-apt-xfce4.sh

"vncserver :1" 
works instead