### PR TITLE
fix the first launch instructions for Arch

### DIFF
--- a/Scripts/Installer/Arch/armhf/arch.sh
+++ b/Scripts/Installer/Arch/armhf/arch.sh
@@ -33,7 +33,7 @@ cat > $bin <<- EOM
 echo " "
 echo " "
 echo " "
-echo "If you are first time starting Arch Linux, you should run this command: chmod 755 && ./additional.sh , this will fix the pacman-key and network problem."
+echo "If you are first time starting Arch Linux, you should run this command: chmod 755 ./additional.sh && ./additional.sh , this will fix the pacman-key and network problem."
 echo " "
 echo " "
 echo " "


### PR DESCRIPTION
I fixed the instructions that the start script for Arch print out. The commands that they previously showed (`chmod 755 && ./additional.sh`) did not work because `chmod` requires a file at the end:
```
Usage: chmod [OPTION]... MODE[,MODE]... FILE...
  or:  chmod [OPTION]... OCTAL-MODE FILE...
  or:  chmod [OPTION]... --reference=RFILE FILE...
```
(source: `chmod --help`)

<br />

Before the changes, simply copying and pasting the commands from the instructions would cause an error:
<img src="https://user-images.githubusercontent.com/50096660/172253571-068e1856-0256-47d1-8349-debcbaf92ad1.png" width="200"/>

Copying and pasting the commands with the slightly changed `chmod` command, it works just fine:
<img src="https://user-images.githubusercontent.com/50096660/172253902-a5fd1f50-5700-47f0-9689-42de14e69275.png" width="200"/>